### PR TITLE
refactor: cobra commands

### DIFF
--- a/cmd/generate_views.go
+++ b/cmd/generate_views.go
@@ -66,4 +66,3 @@ var generateViewsCmd = &cobra.Command{
 		return nil
 	},
 }
-

--- a/cmd/generate_views.go
+++ b/cmd/generate_views.go
@@ -67,6 +67,3 @@ var generateViewsCmd = &cobra.Command{
 	},
 }
 
-func init() {
-	rootCmd.AddCommand(generateViewsCmd)
-}

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -1,102 +1,116 @@
 package cmd
 
 import (
+	"fmt"
 	"github.com/bionic-dev/bionic/database"
 	"github.com/bionic-dev/bionic/internal/progress"
 	"github.com/bionic-dev/bionic/providers"
+	"github.com/bionic-dev/bionic/providers/provider"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 )
 
 var importCmd = &cobra.Command{
-	Use:   "import [provider] [path]",
+	Use:   "import",
 	Short: "Import data to local db",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		providerName, inputPath := args[0], args[1]
-
-		db, err := database.New(dbPath)
-		if err != nil {
-			return err
-		}
-
-		manager, err := providers.NewManager(db, providers.DefaultProviders(db))
-		if err != nil {
-			return err
-		}
-
-		if err := manager.Migrate(); err != nil {
-			return err
-		}
-
-		provider, err := manager.GetByName(providerName)
-		if err != nil {
-			return err
-		}
-
-		importFns, err := provider.ImportFns(inputPath)
-		if err != nil {
-			return err
-		}
-
-		if err := provider.BeginTx(); err != nil {
-			return err
-		}
-		defer provider.RollbackTx() //nolint:errcheck
-
-		errs, _ := errgroup.WithContext(cmd.Context())
-
-		importProgress := progress.New()
-
-		for _, importFn := range importFns {
-			name := importFn.Name()
-			importProgress.Init(name)
-		}
-
-		importProgress.Draw()
-
-		for _, importFn := range importFns {
-			name := importFn.Name()
-			fn := importFn.Call
-
-			errs.Go(func() error {
-				defer importProgress.Draw()
-
-				err := fn()
-
-				if err != nil {
-					importProgress.Error(name)
-					return err
-				}
-
-				importProgress.Success(name)
-
-				return nil
-			})
-		}
-
-		if err := errs.Wait(); err != nil {
-			return err
-		}
-
-		err = provider.DB().
-			Create(&database.Import{
-				Provider: provider.Name(),
-			}).
-			Error
-		if err != nil {
-			return err
-		}
-
-		if err := provider.CommitTx(); err != nil {
-			return err
-		}
-
-		return nil
-	},
-	Args: cobra.MinimumNArgs(2),
 }
 
 func init() {
-	rootCmd.AddCommand(importCmd)
+	for _, p := range providers.DefaultProviders(nil) {
+		providerName := p.Name()
+
+		command := &cobra.Command{
+			Use: fmt.Sprintf("%s [path]", providerName),
+			RunE: func(cmd *cobra.Command, args []string) error {
+				inputPath := args[0]
+
+				db, err := database.New(dbPath)
+				if err != nil {
+					return err
+				}
+
+				manager, err := providers.NewManager(db, providers.DefaultProviders(db))
+				if err != nil {
+					return err
+				}
+
+				if err := manager.Migrate(); err != nil {
+					return err
+				}
+
+				p, err := manager.GetByName(providerName)
+				if err != nil {
+					return err
+				}
+
+				importFns, err := p.ImportFns(inputPath)
+				if err != nil {
+					return err
+				}
+
+				if err := p.BeginTx(); err != nil {
+					return err
+				}
+				defer p.RollbackTx() //nolint:errcheck
+
+				errs, _ := errgroup.WithContext(cmd.Context())
+
+				importProgress := progress.New()
+
+				for _, importFn := range importFns {
+					name := importFn.Name()
+					importProgress.Init(name)
+				}
+
+				importProgress.Draw()
+
+				for _, importFn := range importFns {
+					name := importFn.Name()
+					fn := importFn.Call
+
+					errs.Go(func() error {
+						defer importProgress.Draw()
+
+						err := fn()
+
+						if err != nil {
+							importProgress.Error(name)
+							return err
+						}
+
+						importProgress.Success(name)
+
+						return nil
+					})
+				}
+
+				if err := errs.Wait(); err != nil {
+					return err
+				}
+
+				err = p.DB().
+					Create(&database.Import{
+						Provider: p.Name(),
+					}).
+					Error
+				if err != nil {
+					return err
+				}
+
+				if err := p.CommitTx(); err != nil {
+					return err
+				}
+
+				return nil
+			},
+			Args: cobra.MinimumNArgs(1),
+		}
+
+		if describer, ok := p.(provider.ExportDescriber); ok {
+			command.Short = describer.ExportDescription()
+		}
+
+		importCmd.AddCommand(command)
+	}
 }

--- a/cmd/providers.go
+++ b/cmd/providers.go
@@ -39,6 +39,3 @@ var providersCmd = &cobra.Command{
 	DisableFlagParsing: true,
 }
 
-func init() {
-	rootCmd.AddCommand(providersCmd)
-}

--- a/cmd/providers.go
+++ b/cmd/providers.go
@@ -38,4 +38,3 @@ var providersCmd = &cobra.Command{
 	},
 	DisableFlagParsing: true,
 }
-

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -32,4 +32,3 @@ var resetCmd = &cobra.Command{
 	},
 	Args: cobra.MinimumNArgs(1),
 }
-

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -33,6 +33,3 @@ var resetCmd = &cobra.Command{
 	Args: cobra.MinimumNArgs(1),
 }
 
-func init() {
-	rootCmd.AddCommand(resetCmd)
-}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,6 +36,8 @@ func init() {
 		Use:    "no-help",
 		Hidden: true,
 	})
+
+	rootCmd.AddCommand(importCmd, resetCmd, generateViewsCmd, providersCmd)
 }
 
 func panicOnErr(err error) {


### PR DESCRIPTION
Major change: now not only `bionic providers` prints list of the providers available to import. but also `bionic import` when called without provider.

Example:
```console
➜ bionic (alexey/refactor-commands) ✗ ./build/bionic import
Import data to local db

Usage:
  bionic import [command]

Available Commands:
  google      https://takeout.google.com/
  health      
  instagram   https://www.instagram.com/download/request/
  netflix     
  rescuetime  https://www.rescuetime.com/accounts/your-data => "Your Logged Time" => "Activity report history"
  spotify     
  telegram    Desktop App (https://desktop.telegram.org/ only): Settings => Advanced => Export Telegram data
  twitter     

Flags:
  -h, --help   help for import

Global Flags:
      --db string   db path
      --verbose     verbose output

Use "bionic import [command] --help" for more information about a command.
```